### PR TITLE
- Allow the user agent to be specified when the SDK is used

### DIFF
--- a/Okta.Core/Clients/AppGroupsClient.cs
+++ b/Okta.Core/Clients/AppGroupsClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="App"/>s for a <see cref="Group"/>
     /// </summary>
@@ -17,17 +11,17 @@ namespace Okta.Core.Clients
         public AppGroupsClient(App app, OktaSettings oktaSettings) : base(oktaSettings, Constants.EndpointV1 + Constants.AppsEndpoint + "/" + app.Id + Constants.GroupsEndpoint) { }
         public AppGroupsClient(App app, string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.AppsEndpoint + "/" + app.Id + Constants.GroupsEndpoint) { }
 
-        public AppGroup Add(Group group)
+        public virtual AppGroup Add(Group group)
         {
             return base.Update(group.Id, Constants.EmptyObject);
         }
 
-        public AppGroup Get(AppGroup appGroup)
+        public virtual AppGroup Get(AppGroup appGroup)
         {
             return base.Get(appGroup);
         }
 
-        public void Remove(Group group)
+        public virtual void Remove(Group group)
         {
             base.Remove(group.Id);
         }

--- a/Okta.Core/Clients/AppUsersClient.cs
+++ b/Okta.Core/Clients/AppUsersClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="User"/>s of an <see cref="App"/>
     /// </summary>
@@ -17,17 +11,17 @@ namespace Okta.Core.Clients
         public AppUsersClient(App app, OktaSettings oktaSettings) : base(oktaSettings, Constants.EndpointV1 + Constants.AppsEndpoint + "/" + app.Id + Constants.UsersEndpoint) { }
         public AppUsersClient(App app, string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.AppsEndpoint + "/" + app.Id + Constants.UsersEndpoint) { }
 
-        public AppUser Add(User user)
+        public virtual AppUser Add(User user)
         {
             return base.Update(user.Id, Constants.EmptyObject);
         }
 
-        public AppUser Get(AppUser appUser)
+        public virtual AppUser Get(AppUser appUser)
         {
             return base.Get(appUser);
         }
 
-        public void Remove(User user)
+        public virtual void Remove(User user)
         {
             base.Remove(user.Id);
         }

--- a/Okta.Core/Clients/AppsClient.cs
+++ b/Okta.Core/Clients/AppsClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="App"/>s
     /// </summary>
@@ -17,57 +11,57 @@ namespace Okta.Core.Clients
         public AppsClient(OktaSettings oktaSettings) : base(oktaSettings, Constants.EndpointV1 + Constants.AppsEndpoint) { }
         public AppsClient(string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.AppsEndpoint) { }
 
-        public App Add(App app)
+        public virtual App Add(App app)
         {
             return base.Add(app);
         }
 
-        public AppUser Add(App app, User user)
+        public virtual AppUser Add(App app, User user)
         {
             return GetAppUsersClient(app).Add(user);
         }
 
-        public AppGroup Add(App app, Group group)
+        public virtual AppGroup Add(App app, Group group)
         {
             return GetAppGroupsClient(app).Add(group);
         }
 
-        public App Update(App app)
+        public virtual App Update(App app)
         {
             return base.Update(app);
         }
 
-        public void Remove(App app)
+        public virtual void Remove(App app)
         {
             base.Remove(app);
         }
             
-        public void Remove(App app, User user)
+        public virtual void Remove(App app, User user)
         {
             GetAppUsersClient(app).Remove(user);
         }
 
-        public void Remove(App app, Group group)
+        public virtual void Remove(App app, Group group)
         {
             GetAppGroupsClient(app).Remove(group);
         }
 
-        public void Activate(App app)
+        public virtual void Activate(App app)
         {
             PerformLifecycle(app, Constants.LifecycleActivate);
         }
 
-        public void Deactivate(App app)
+        public virtual void Deactivate(App app)
         {
             PerformLifecycle(app, Constants.LifecycleDeactivate);
         }
 
-        public AppUsersClient GetAppUsersClient(App app)
+        public virtual AppUsersClient GetAppUsersClient(App app)
         {
             return new AppUsersClient(app, BaseClient);
         }
 
-        public AppGroupsClient GetAppGroupsClient(App app)
+        public virtual AppGroupsClient GetAppGroupsClient(App app)
         {
             return new AppGroupsClient(app, BaseClient);
         }

--- a/Okta.Core/Clients/AuthClient.cs
+++ b/Okta.Core/Clients/AuthClient.cs
@@ -1,13 +1,10 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using System;
+    using System.Linq;
+
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage the authentication flow.
     /// </summary>
@@ -19,11 +16,11 @@ namespace Okta.Core.Clients
 
         protected string resourcePath { get; set; }
 
-        public AuthResponse Authenticate(string username, string password, string relayState = null)
+        public virtual AuthResponse Authenticate(string username, string password, string relayState = null)
         {
-            var authRequest = new AuthRequest() {
-                Username = username,
-                Password = password,
+            var authRequest = new AuthRequest {
+                Username = username, 
+                Password = password, 
                 RelayState = relayState
             };
 
@@ -31,21 +28,21 @@ namespace Okta.Core.Clients
             return Utils.Deserialize<AuthResponse>(response);
         }
 
-        public AuthResponse Enroll(string stateToken, Factor factor)
+        public virtual AuthResponse Enroll(string stateToken, Factor factor)
         {
             factor.SetProperty("stateToken", stateToken);
             var response = BaseClient.Post(resourcePath + Constants.FactorsEndpoint, factor.ToJson());
             return Utils.Deserialize<AuthResponse>(response);
         }
 
-        public AuthResponse Verify(string stateToken, Factor factor, MfaAnswer answer = null)
+        public virtual AuthResponse Verify(string stateToken, Factor factor, MfaAnswer answer = null)
         {
             // This is "Href" and not "First()" because this is a "Factor Links Object" - remove this line?
             var verifyLink = factor.Links["verify"].First().Href;
             return Execute(stateToken, verifyLink, answer);
         }
 
-        public AuthResponse ActivateTotpFactor(string stateToken, AuthResponse authResponse, string passCode)
+        public virtual AuthResponse ActivateTotpFactor(string stateToken, AuthResponse authResponse, string passCode)
         {
             var apiObject = new ApiObject();
             apiObject.SetProperty("passCode", passCode);
@@ -53,7 +50,7 @@ namespace Okta.Core.Clients
             return Execute(stateToken, nextLink, apiObject);
         }
 
-        public AuthResponse ValidateToken(string recoveryToken)
+        public virtual AuthResponse ValidateToken(string recoveryToken)
         {
             var apiObject = new ApiObject();
             apiObject.SetProperty("recoveryToken", recoveryToken);
@@ -61,7 +58,7 @@ namespace Okta.Core.Clients
             return Utils.Deserialize<AuthResponse>(response);
         }
 
-        public AuthResponse GetStatus(string stateToken)
+        public virtual AuthResponse GetStatus(string stateToken)
         {
             var apiObject = new ApiObject();
             apiObject.SetProperty("stateToken", stateToken);
@@ -69,12 +66,12 @@ namespace Okta.Core.Clients
             return Utils.Deserialize<AuthResponse>(response);
         }
 
-        public AuthResponse Execute(string stateToken, Link link, ApiObject apiObject = null)
+        public virtual AuthResponse Execute(string stateToken, Link link, ApiObject apiObject = null)
         {
             return Execute(stateToken, link.Href, apiObject);
         }
 
-        public AuthResponse Execute(string stateToken, Uri uri, ApiObject apiObject = null)
+        public virtual AuthResponse Execute(string stateToken, Uri uri, ApiObject apiObject = null)
         {
             // Create a new apiObject if it's null, because we need to add a stateToken
             apiObject = apiObject ?? new ApiObject();

--- a/Okta.Core/Clients/AuthenticatedClient.cs
+++ b/Okta.Core/Clients/AuthenticatedClient.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using System;
+
     /// <summary>
     /// An http client that handles authentication with Okta
     /// </summary>
@@ -23,6 +20,7 @@ namespace Okta.Core.Clients
             get { return this.BaseClient.ApiToken; }
             set { this.BaseClient.ApiToken = value; }
         }
+
         /// <summary>
         /// Gets the base URI.
         /// </summary>
@@ -55,9 +53,8 @@ namespace Okta.Core.Clients
         /// <param name="baseUri">The base URI.</param>
         public AuthenticatedClient(string apiToken, Uri baseUri)
         {
-            var oktaSettings = new OktaSettings()
-            {
-                ApiToken = apiToken,
+            var oktaSettings = new OktaSettings {
+                ApiToken = apiToken, 
                 BaseUri = baseUri
             };
 

--- a/Okta.Core/Clients/EventsClient.cs
+++ b/Okta.Core/Clients/EventsClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to list and query <see cref="Event"/>s
     /// </summary>

--- a/Okta.Core/Clients/GroupUsersClient.cs
+++ b/Okta.Core/Clients/GroupUsersClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="User"/>s in a <see cref="Group"/>
     /// </summary>
@@ -17,9 +11,9 @@ namespace Okta.Core.Clients
         public GroupUsersClient(Group group, OktaSettings oktaSettings) : base(oktaSettings, Constants.EndpointV1 + Constants.GroupsEndpoint + "/" + group.Id + Constants.UsersEndpoint) { }
         public GroupUsersClient(Group group, string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.GroupsEndpoint + "/" + group.Id + Constants.UsersEndpoint) { }
 
-        public User Add(User oktaObject)
+        public virtual User Add(User oktaObject)
         {
-            var result = BaseClient.Put(resourcePath + "/" + oktaObject.Id, null);
+            BaseClient.Put(resourcePath + "/" + oktaObject.Id);
             return oktaObject;
         }
 

--- a/Okta.Core/Clients/GroupsClient.cs
+++ b/Okta.Core/Clients/GroupsClient.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="Group"/>s
     /// </summary>
@@ -15,22 +11,22 @@ namespace Okta.Core.Clients
         public GroupsClient(OktaSettings oktaSettings) : base(oktaSettings, Constants.EndpointV1 + Constants.GroupsEndpoint) { }
         public GroupsClient(string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.GroupsEndpoint) { }
 
-        public Group Add(Group group)
+        public virtual Group Add(Group group)
         {
             return base.Add(group);
         }
 
-        public Group Get(Group group)
+        public virtual Group Get(Group group)
         {
             return base.Get(group);
         }
 
-        public Group Get(string groupId)
+        public virtual Group Get(string groupId)
         {
             return base.Get(groupId);
         }
 
-        public Group GetByName(string groupName)
+        public virtual Group GetByName(string groupName)
         {
             Group g = null;
             PagedResults<Group> groups = this.GetList(query: groupName);
@@ -41,22 +37,22 @@ namespace Okta.Core.Clients
             return g;
         }
 
-        public Group Update(Group group)
+        public virtual Group Update(Group group)
         {
             return base.Update(group);
         }
 
-        public void Remove(Group group)
+        public virtual void Remove(Group group)
         {
             base.Remove(group);
         }
 
-        public void Remove(string groupId)
+        public virtual void Remove(string groupId)
         {
             base.Remove(groupId);
         }
 
-        public GroupUsersClient GetGroupUsersClient(Group group)
+        public virtual GroupUsersClient GetGroupUsersClient(Group group)
         {
             return new GroupUsersClient(group, BaseClient);
         }

--- a/Okta.Core/Clients/OktaClient.cs
+++ b/Okta.Core/Clients/OktaClient.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using System;
+
+    using Okta.Core.Models;
+
     /// <summary>
     /// A convenience client to build all other clients without building a new <see cref="AuthenticatedClient.BaseClient"/> for every one.
     /// </summary>
@@ -15,72 +13,72 @@ namespace Okta.Core.Clients
         public OktaClient(string apiToken, Uri baseUri) : base(apiToken, baseUri) { }
         public OktaClient(OktaSettings oktaSettings) : base(oktaSettings) { }
 
-        public UsersClient GetUsersClient()
+        public virtual UsersClient GetUsersClient()
         {
             return new UsersClient(BaseClient);
         }
 
-        public UserGroupsClient GetUserGroupsClient(User user)
+        public virtual UserGroupsClient GetUserGroupsClient(User user)
         {
             return new UserGroupsClient(user, BaseClient);
         }
 
-        public UserFactorsClient GetUserFactorsClient(User user)
+        public virtual UserFactorsClient GetUserFactorsClient(User user)
         {
             return new UserFactorsClient(user, BaseClient);
         }
 
-        public UserAppLinksClient GetUserAppLinksClient(User user)
+        public virtual UserAppLinksClient GetUserAppLinksClient(User user)
         {
             return new UserAppLinksClient(user, BaseClient);
         }
 
-        public GroupsClient GetGroupsClient()
+        public virtual GroupsClient GetGroupsClient()
         {
             return new GroupsClient(BaseClient);
         }
 
-        public GroupUsersClient GetGroupUsersClient(Group group)
+        public virtual GroupUsersClient GetGroupUsersClient(Group group)
         {
             return new GroupUsersClient(group, BaseClient);
         }
 
-        public AppsClient GetAppsClient()
+        public virtual AppsClient GetAppsClient()
         {
             return new AppsClient(BaseClient);
         }
 
-        public AppUsersClient GetAppUsersClient(App app)
+        public virtual AppUsersClient GetAppUsersClient(App app)
         {
             return new AppUsersClient(app, BaseClient);
         }
 
-        public AppGroupsClient GetAppGroupsClient(App app)
+        public virtual AppGroupsClient GetAppGroupsClient(App app)
         {
             return new AppGroupsClient(app, BaseClient);
         }
 
-        public AuthClient GetAuthClient()
+        public virtual AuthClient GetAuthClient()
         {
             return new AuthClient(BaseClient);
         }
 
-        public EventsClient GetEventsClient()
+        public virtual EventsClient GetEventsClient()
         {
             return new EventsClient(BaseClient);
         }
 
-        public SessionsClient GetSessionsClient()
+        public virtual SessionsClient GetSessionsClient()
         {
             return new SessionsClient(BaseClient);
         }
 
-        public OrgFactorsClient GetOrgFactorsClient()
+        public virtual OrgFactorsClient GetOrgFactorsClient()
         {
             return new OrgFactorsClient(BaseClient);
         }
 
-        public UserSchemasClient GetUserTypesClient()
+        public virtual UserSchemasClient GetUserTypesClient()
         {
             return new UserSchemasClient(BaseClient);
         }

--- a/Okta.Core/Clients/OrgFactorsClient.cs
+++ b/Okta.Core/Clients/OrgFactorsClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="Factor"/>s for an org
     /// </summary>
@@ -18,47 +12,46 @@ namespace Okta.Core.Clients
         public OrgFactorsClient(string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.OrgEndpoint + Constants.FactorsEndpoint) { }
 
         // TODO: Maybe try a TryActivate/TryDeactivate
-
-        public Factor Activate(string id)
+        public virtual Factor Activate(string id)
         {
             var response = PerformLifecycle(id, "activate");
             return Utils.Deserialize<Factor>(response);
         }
 
-        public Factor Activate(Factor factor)
+        public virtual Factor Activate(Factor factor)
         {
             var response = PerformLifecycle(factor, "activate");
             return Utils.Deserialize<Factor>(response);
         }
 
-        public Factor Deactivate(string id)
+        public virtual Factor Deactivate(string id)
         {
             var response = PerformLifecycle(id, "deactivate");
             return Utils.Deserialize<Factor>(response);
         }
 
-        public Factor Deactivate(Factor factor)
+        public virtual Factor Deactivate(Factor factor)
         {
             var response = PerformLifecycle(factor, "deactivate");
             return Utils.Deserialize<Factor>(response);
         }
 
-        public Factor ActivateQuestion()
+        public virtual Factor ActivateQuestion()
         {
             return Activate(Constants.MfaTypes.SecurityQuestion);
         }
 
-        public Factor DeactivateQuestion()
+        public virtual Factor DeactivateQuestion()
         {
             return Deactivate(Constants.MfaTypes.SecurityQuestion);
         }
 
-        public Factor ActivateSms()
+        public virtual Factor ActivateSms()
         {
             return Activate(Constants.MfaTypes.SMS);
         }
 
-        public Factor DeactivateSms()
+        public virtual Factor DeactivateSms()
         {
             return Deactivate(Constants.MfaTypes.SMS);
         }
@@ -67,17 +60,17 @@ namespace Okta.Core.Clients
         /// Activates the Yubikey factor - will throws a "Yubikey seed file is not uploaded yet." error if a Yubikey seed file has not been uploaded yet
         /// </summary>
         /// <returns></returns>
-        public Factor ActivateYubikey()
+        public virtual Factor ActivateYubikey()
         {
             return Activate(Constants.MfaTypes.Yubikey);
         }
 
-        public Factor DeactivateYubikey()
+        public virtual Factor DeactivateYubikey()
         {
             return Deactivate(Constants.MfaTypes.Yubikey);
         }
 
-        public Factor GetFactor(string strMfaType)
+        public virtual Factor GetFactor(string strMfaType)
         {
             Factor factor = null;
             PagedResults<Models.Factor> factors = this.GetList();
@@ -92,7 +85,7 @@ namespace Okta.Core.Clients
             return factor;
         }
 
-        public bool IsFactorSetup(string factorId)
+        public virtual bool IsFactorSetup(string factorId)
         {
             bool bNotSetup = false;
             PagedResults<Models.Factor> factors = this.GetList();

--- a/Okta.Core/Clients/SessionsClient.cs
+++ b/Okta.Core/Clients/SessionsClient.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="Session"/>s. See the <see cref="AuthClient"/> for flows with MFA.
     /// </summary>
@@ -17,11 +16,11 @@ namespace Okta.Core.Clients
         public SessionsClient(string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.SessionsEndpoint) { }
 
         // TODO: Determine whether this is reasonable. If we don't provide a token attribute, then we don't get a token
-        public Session Create(string login, string password, TokenAttribute? tokenAttribute = null)
+        public virtual Session Create(string login, string password, TokenAttribute? tokenAttribute = null)
         {
             // Create a temporary credentials object
             var credentials = new Dictionary<string, object> {
-                {"username", login},
+                {"username", login}, 
                 {"password", password}
             };
 
@@ -29,13 +28,12 @@ namespace Okta.Core.Clients
             var serializedCredentials = Utils.SerializeObject(credentials);
 
             HttpResponseMessage results;
-            var urlParameters = "";
+            var urlParameters = string.Empty;
             if(tokenAttribute != null)
             {
                 // Add the token attribute as a url param
                 var serializedTokenAttribute = Utils.SerializeObject(tokenAttribute).Trim('"');
-                var urlParams = new Dictionary<string, object>()
-                {
+                var urlParams = new Dictionary<string, object> {
                     {"additionalFields", serializedTokenAttribute}
                 };
                 urlParameters = Utils.BuildUrlParams(urlParams);
@@ -46,25 +44,25 @@ namespace Okta.Core.Clients
             return Utils.Deserialize<Session>(results);
         }
 
-        public Session Validate(Session session) { return Validate(session.Id); }
-        public Session Validate(string id)
+        public virtual Session Validate(Session session) { return Validate(session.Id); }
+        public virtual Session Validate(string id)
         {
             return Get(id);
         }
 
-        public Session Extend(Session session) { return Update(session); }
-        public Session Extend(string id) { return Update(id); }
+        public virtual Session Extend(Session session) { return Update(session); }
+        public virtual Session Extend(string id) { return Update(id); }
 
-        public void Close(Session session) { base.Remove(session); }
-        public void Close(string id) { base.Remove(id); }
+        public virtual void Close(Session session) { this.Remove(session); }
+        public virtual void Close(string id) { this.Remove(id); }
 
         // Create a session url string with a cookieToken and final redirectUrl.
         // Send the user a redirect to the resulting url to set a cookie.
-        public String CreateSessionUrlString(String cookieToken, Uri redirectUrl)
+        public virtual string CreateSessionUrlString(string cookieToken, Uri redirectUrl)
         {
             var sessionRedirectUrlFormat = "{0}login/sessionCookieRedirect?token={1}&redirectUrl={2}";
-            var encodedUrl = Uri.EscapeDataString(redirectUrl.ToString()).ToString();
-            return String.Format(sessionRedirectUrlFormat, this.BaseUri.ToString(), cookieToken, encodedUrl);
+            var encodedUrl = Uri.EscapeDataString(redirectUrl.ToString());
+            return string.Format(sessionRedirectUrlFormat, this.BaseUri, cookieToken, encodedUrl);
         }
     }
 }

--- a/Okta.Core/Clients/UserAppLinksClient.cs
+++ b/Okta.Core/Clients/UserAppLinksClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="AppLink"/>s for a <see cref="User"/>
     /// </summary>

--- a/Okta.Core/Clients/UserFactorsClient.cs
+++ b/Okta.Core/Clients/UserFactorsClient.cs
@@ -1,13 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using System.Collections.Generic;
+
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="Factor"/>s for a <see cref="User"/>
     /// </summary>
@@ -17,30 +13,30 @@ namespace Okta.Core.Clients
         public UserFactorsClient(User user, OktaSettings oktaSettings) : base(oktaSettings, Constants.EndpointV1 + Constants.UsersEndpoint + "/" + user.Id + Constants.FactorsEndpoint) { }
         public UserFactorsClient(User user, string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.UsersEndpoint + "/" + user.Id + Constants.FactorsEndpoint) { }
 
-        public List<Factor> GetFactorCatalog()
+        public virtual List<Factor> GetFactorCatalog()
         {
             var response = BaseClient.Get(resourcePath + Constants.CatalogEndpoint);
             return Utils.Deserialize<List<Factor>>(response);
         }
 
-        public List<Question> GetQuestions()
+        public virtual List<Question> GetQuestions()
         {
             var response = BaseClient.Get(resourcePath + Constants.QuestionsEndpoint);
             return Utils.Deserialize<List<Question>>(response);
         }
 
-        public Factor Enroll(Factor factor)
+        public virtual Factor Enroll(Factor factor)
         {
             return base.Add(factor);
         }
 
-        public Factor EnrollQuestion(string questionType, string answer)
+        public virtual Factor EnrollQuestion(string questionType, string answer)
         {
             var question = Factor.BuildQuestion(questionType, answer);
             return Enroll(question);
         }
 
-        public Factor Activate(Factor factor, string passCode)
+        public virtual Factor Activate(Factor factor, string passCode)
         {
             //string body = "{ passCode: " + passCode +"}";
             string body = string.Format("{{ \"passCode\": \"{0}\" }}", passCode);
@@ -49,21 +45,19 @@ namespace Okta.Core.Clients
 
             //return base.PerformLifecycle()
         }
-
-
-        public void Reset(Factor factor)
+        public virtual void Reset(Factor factor)
         {
             base.Remove(factor);
         }
 
-        public void Reset(string factorId)
+        public virtual void Reset(string factorId)
         {
             base.Remove(factorId);
         }
 
-        public ChallengeResponse BeginChallenge(Factor factor)
+        public virtual ChallengeResponse BeginChallenge(Factor factor)
         {
-            var response = BaseClient.Post(GetResourceUri(factor).ToString() + Constants.VerifyEndpoint);
+            var response = BaseClient.Post(this.GetResourceUri(factor) + Constants.VerifyEndpoint);
             return Utils.Deserialize<ChallengeResponse>(response);
         }
 
@@ -73,13 +67,13 @@ namespace Okta.Core.Clients
         /// <param name="factor">the Factor security question object used to validate the answer</param>
         /// <param name="mfaAnswer">an object of type MfaAnswer used to validate the answer</param>
         /// <returns></returns>
-        public ChallengeResponse CompleteChallenge(Factor factor, MfaAnswer mfaAnswer)
+        public virtual ChallengeResponse CompleteChallenge(Factor factor, MfaAnswer mfaAnswer)
         {
-            var response = BaseClient.Post(GetResourceUri(factor).ToString() + Constants.VerifyEndpoint, mfaAnswer.ToJson());
+            var response = BaseClient.Post(this.GetResourceUri(factor) + Constants.VerifyEndpoint, mfaAnswer.ToJson());
             return Utils.Deserialize<ChallengeResponse>(response);
         }
 
-        public ChallengeResponse PollTransaction(string strPollUrl)
+        public virtual ChallengeResponse PollTransaction(string strPollUrl)
         {
             //replace double forward slashes which would otherwise create an invalid request - API BUG?
             strPollUrl = strPollUrl.Replace("//verify", "/verify");

--- a/Okta.Core/Clients/UserGroupsClient.cs
+++ b/Okta.Core/Clients/UserGroupsClient.cs
@@ -1,13 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="Group"/>s for a <see cref="User"/>
     /// </summary>

--- a/Okta.Core/Clients/UserSchemasClient.cs
+++ b/Okta.Core/Clients/UserSchemasClient.cs
@@ -1,11 +1,7 @@
-﻿using Okta.Core.Models.Schemas;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using Okta.Core.Models.Schemas;
+
     /// <summary>
     /// A client to read the schemas of your Okta <see cref="User"/>
     /// </summary>
@@ -23,7 +19,7 @@ namespace Okta.Core.Clients
             base(apiToken, subdomain, Constants.EndpointV1 + Constants.UserSchemasEndpoint) 
         { }
 
-        public Schema Get()
+        public virtual Schema Get()
         {
             var result = BaseClient.Get(resourcePath);
             return Utils.Deserialize<Schema>(result);

--- a/Okta.Core/Clients/UsersClient.cs
+++ b/Okta.Core/Clients/UsersClient.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core.Clients
+﻿namespace Okta.Core.Clients
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Okta.Core.Models;
+
     /// <summary>
     /// A client to manage <see cref="User"/>s
     /// </summary>
@@ -16,13 +14,13 @@ namespace Okta.Core.Clients
         public UsersClient(OktaSettings oktaSettings) : base(oktaSettings, Constants.EndpointV1 + Constants.UsersEndpoint) { }
         public UsersClient(string apiToken, string subdomain) : base(apiToken, subdomain, Constants.EndpointV1 + Constants.UsersEndpoint) { }
 
-        public User Add(User user, bool activate = true)
+        public virtual User Add(User user, bool activate = true)
         {
             var urlParams = new Dictionary<string, object> { { "activate", activate } };
             return base.Add(user, urlParams);
         }
 
-        public User Get(User user)
+        public virtual User Get(User user)
         {
             return base.Get(user);
         }
@@ -34,18 +32,18 @@ namespace Okta.Core.Clients
         /// <returns>An Okta User object if it exists</returns>
         /// <exception cref="OktaException">Returns an E0000007 exception if the user is not found</exception>
         /// <example>userClient.Get("user@domain.local") or userClient.Get("00u5t0pkimhkCPyGo0h7")</example>
-        public User Get(string userId)
+        public virtual User Get(string userId)
         {
             return base.Get(userId);
         }
 
-        ///// <summary>
-        ///// Retrieves an Okta user given its Username property (which is unique) by using a filter=profile.login eq '[username]' filter
-        ///// </summary>
-        ///// <param name="userName">Username/login property of the Okta user</param>
-        ///// <returns>An Okta User object if it exists or a null object if it doesn't exist</returns>
+        /// <summary>
+        /// Retrieves an Okta user given its Username property (which is unique) by using a filter=profile.login eq '[username]' filter
+        /// </summary>
+        /// <param name="userName">Username/login property of the Okta user</param>
+        /// <returns>An Okta User object if it exists or a null object if it doesn't exist</returns>
         /// <example>userClient.GetByUsername("user@domain.local") or userClient.GetByUsername("user")</example>
-        public User GetByUsername(string userName)
+        public virtual User GetByUsername(string userName)
         {
             User user = null;
             var filter = new FilterBuilder();
@@ -60,46 +58,44 @@ namespace Okta.Core.Clients
             return user;
         }
 
-        public User Update(User user)
+        public virtual User Update(User user)
         {
             return base.Update(user);
         }
 
-        public User SetCredentials(User user, LoginCredentials credentials)
+        public virtual User SetCredentials(User user, LoginCredentials credentials)
         {
-            var userWithCredentials = new User()
-            {
+            var userWithCredentials = new User {
                 Credentials = credentials
             };
             var results = BaseClient.Put(GetResourceUri(user), userWithCredentials.ToJson());
             return Utils.Deserialize<User>(results);
         }
 
-        public User SetCredentials(string id, LoginCredentials credentials)
+        public virtual User SetCredentials(string id, LoginCredentials credentials)
         {
-            var userWithCredentials = new User()
-            {
+            var userWithCredentials = new User {
                 Credentials = credentials
             };
             var results = BaseClient.Put(id, userWithCredentials.ToJson());
             return Utils.Deserialize<User>(results);
         }
 
-        public User SetPassword(User user, string newPassword)
+        public virtual User SetPassword(User user, string newPassword)
         {
             var credentials = new LoginCredentials();
             credentials.Password.Value = newPassword;
             return SetCredentials(user, credentials);
         }
 
-        public User SetPassword(string id, string newPassword)
+        public virtual User SetPassword(string id, string newPassword)
         {
             var credentials = new LoginCredentials();
             credentials.Password.Value = newPassword;
             return SetCredentials(id, credentials);
         }
 
-        public User SetRecoveryQuestion(User user, string question, string answer)
+        public virtual User SetRecoveryQuestion(User user, string question, string answer)
         {
             var credentials = new LoginCredentials();
             credentials.RecoveryQuestion.Question = question;
@@ -107,7 +103,7 @@ namespace Okta.Core.Clients
             return SetCredentials(user, credentials);
         }
 
-        public User SetRecoveryQuestion(string id, string question, string answer)
+        public virtual User SetRecoveryQuestion(string id, string question, string answer)
         {
             var credentials = new LoginCredentials();
             credentials.RecoveryQuestion.Question = question;
@@ -115,7 +111,7 @@ namespace Okta.Core.Clients
             return SetCredentials(id, credentials);
         }
 
-        public Uri Activate(User user, bool sendEmail = true)
+        public virtual Uri Activate(User user, bool sendEmail = true)
         {
             // TODO: Should this return a Uri or an activation response?
             var response = PerformLifecycle(user, Constants.LifecycleActivate, urlParams: new Dictionary<string, object> { { "sendEmail", sendEmail } });
@@ -123,58 +119,54 @@ namespace Okta.Core.Clients
             {
                 return null;
             }
-            else
-            {
-                var activationResult = Utils.Deserialize<ActivationResponse>(response);
-                return activationResult.ActivationUrl;
-            }
+
+            var activationResult = Utils.Deserialize<ActivationResponse>(response);
+            return activationResult.ActivationUrl;
         }
 
-        public Uri Activate(string id, bool sendEmail = true)
+        public virtual Uri Activate(string id, bool sendEmail = true)
         {
             var response = PerformLifecycle(id, Constants.LifecycleActivate, urlParams: new Dictionary<string, object> { { "sendEmail", sendEmail } });
             if (sendEmail)
             {
                 return null;
             }
-            else
-            {
-                var activationResult = Utils.Deserialize<ActivationResponse>(response);
-                return activationResult.ActivationUrl;
-            }
+
+            var activationResult = Utils.Deserialize<ActivationResponse>(response);
+            return activationResult.ActivationUrl;
         }
 
-        public void Deactivate(User user)
+        public virtual void Deactivate(User user)
         {
             PerformLifecycle(user, Constants.LifecycleDeactivate);
         }
 
-        public void Deactivate(string id)
+        public virtual void Deactivate(string id)
         {
             PerformLifecycle(id, Constants.LifecycleDeactivate);
         }
 
-        public void Unlock(User user)
+        public virtual void Unlock(User user)
         {
             PerformLifecycle(user, Constants.LifecycleUnlock);
         }
 
-        public void Unlock(string id)
+        public virtual void Unlock(string id)
         {
             PerformLifecycle(id, Constants.LifecycleUnlock);
         }
 
-        public void ResetPassword(User user)
+        public virtual void ResetPassword(User user)
         {
             PerformLifecycle(user, Constants.LifecycleResetPassword);
         }
 
-        public void ResetPassword(string id)
+        public virtual void ResetPassword(string id)
         {
             PerformLifecycle(id, Constants.LifecycleResetPassword);
         }
 
-        public string ExpirePassword(User user, bool tempPassword = false)
+        public virtual string ExpirePassword(User user, bool tempPassword = false)
         {
             var response = PerformLifecycle(user, Constants.LifecycleExpirePassword, urlParams: new Dictionary<string, object> { { "tempPassword", tempPassword } });
             if (tempPassword)
@@ -182,13 +174,11 @@ namespace Okta.Core.Clients
                 var expirePasswordResult = Utils.Deserialize<ExpirePasswordResponse>(response);
                 return expirePasswordResult.TempPassword;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
-        public string ExpirePassword(string id, bool tempPassword = false)
+        public virtual string ExpirePassword(string id, bool tempPassword = false)
         {
             var response = PerformLifecycle(id, Constants.LifecycleExpirePassword, urlParams: new Dictionary<string, object> { { "tempPassword", tempPassword } });
             if (tempPassword)
@@ -196,52 +186,48 @@ namespace Okta.Core.Clients
                 var expirePasswordResult = Utils.Deserialize<ExpirePasswordResponse>(response);
                 return expirePasswordResult.TempPassword;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
-        public void ResetFactors(User user)
+        public virtual void ResetFactors(User user)
         {
             PerformLifecycle(user, Constants.LifecycleResetFactors);
         }
 
-        public void ResetFactors(string id)
+        public virtual void ResetFactors(string id)
         {
             PerformLifecycle(id, Constants.LifecycleResetFactors);
         }
 
-        public Uri ForgotPassword(User user, bool sendEmail = true)
+        public virtual Uri ForgotPassword(User user, bool sendEmail = true)
         {
             var response = PerformLifecycle(user, Constants.LifecycleForgotPassword, urlParams: new Dictionary<string, object> { { "sendEmail", sendEmail } });
             if (sendEmail)
             {
                 return null;
             }
-            else
-            {
-                var forgotPasswordResult = Utils.Deserialize<ForgotPasswordResponse>(response);
-                return forgotPasswordResult.ResetPasswordUrl;
-            }
+
+            var forgotPasswordResult = Utils.Deserialize<ForgotPasswordResponse>(response);
+            return forgotPasswordResult.ResetPasswordUrl;
         }
 
-        public void ForgotPassword(string id)
+        public virtual void ForgotPassword(string id)
         {
             PerformLifecycle(id, Constants.LifecycleForgotPassword);
         }
 
-        public LoginCredentials ForgotPassword(User user, LoginCredentials creds)
+        public virtual LoginCredentials ForgotPassword(User user, LoginCredentials creds)
         {
             var response = PerformLifecycle(user, Constants.LifecycleForgotPassword, creds.ToJson());
             return Utils.Deserialize<LoginCredentials>(response);
         }
 
-        public LoginCredentials ChangePassword(User user, String oldPassword, String newPassword)
+        public virtual LoginCredentials ChangePassword(User user, string oldPassword, string newPassword)
         {
             var passwordRequestObject = new
             {
-                oldPassword = new { value = oldPassword },
+                oldPassword = new { value = oldPassword }, 
                 newPassword = new { value = newPassword }
             };
             var passwordRequest = Utils.SerializeObject(passwordRequestObject);
@@ -249,11 +235,11 @@ namespace Okta.Core.Clients
             return Utils.Deserialize<LoginCredentials>(response);
         }
 
-        public LoginCredentials ChangeRecoveryQuestion(User user, String currentPassword, RecoveryQuestion newRecoveryQuestion)
+        public virtual LoginCredentials ChangeRecoveryQuestion(User user, string currentPassword, RecoveryQuestion newRecoveryQuestion)
         {
             var recoveryQuestionObject = new
             {
-                password = new { value = currentPassword },
+                password = new { value = currentPassword }, 
                 recovery_question = newRecoveryQuestion
             };
             var recoveryQuestionRequest = Utils.SerializeObject(recoveryQuestionObject);
@@ -261,17 +247,17 @@ namespace Okta.Core.Clients
             return Utils.Deserialize<LoginCredentials>(response);
         }
 
-        public UserAppLinksClient GetUserAppLinksClient(User user)
+        public virtual UserAppLinksClient GetUserAppLinksClient(User user)
         {
             return new UserAppLinksClient(user, BaseClient);
         }
 
-        public UserFactorsClient GetUserFactorsClient(User user)
+        public virtual UserFactorsClient GetUserFactorsClient(User user)
         {
             return new UserFactorsClient(user, BaseClient);
         }
 
-        public UserGroupsClient GetUserGroupsClient(User user)
+        public virtual UserGroupsClient GetUserGroupsClient(User user)
         {
             return new UserGroupsClient(user, BaseClient);
         }

--- a/Okta.Core/EnumerableResults.cs
+++ b/Okta.Core/EnumerableResults.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Okta.Core.Models;
-using Okta.Core.Clients;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    using Okta.Core.Clients;
+    using Okta.Core.Models;
+
     /// <summary>
     /// An enumerable list of <see cref="Okta.Core.Models.OktaObject"/>s
     /// </summary>
@@ -44,7 +43,7 @@ namespace Okta.Core
             return ResultsEnumerator();
         }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator()
         {
             // Lets call the generic version here
             return this.GetEnumerator();

--- a/Okta.Core/Exceptions/OktaAuthenticationException.cs
+++ b/Okta.Core/Exceptions/OktaAuthenticationException.cs
@@ -1,19 +1,17 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An <see cref="OktaException"/> thrown for authentication issues
     /// </summary>
     public class OktaAuthenticationException : OktaException
     {
         [JsonConstructor]
-        public OktaAuthenticationException() : base() { }
+        public OktaAuthenticationException()
+        { }
         public OktaAuthenticationException(string message) : base(message) { }
         public OktaAuthenticationException(string message, Exception exception) : base(message, exception) { }
         public OktaAuthenticationException(OktaException oktaException) : base(oktaException) { }

--- a/Okta.Core/Exceptions/OktaErrorCodes.cs
+++ b/Okta.Core/Exceptions/OktaErrorCodes.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
     /// <summary>
     /// A list of possible Okta error codes

--- a/Okta.Core/Exceptions/OktaException.cs
+++ b/Okta.Core/Exceptions/OktaException.cs
@@ -1,12 +1,10 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+    using System.Net;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An Okta-specific exception
     /// </summary>
@@ -14,7 +12,8 @@ namespace Okta.Core
     public class OktaException : Exception
     {
         [JsonConstructor]
-        public OktaException() : base() { }
+        public OktaException()
+        { }
         public OktaException(string message) : base(message) { }
         public OktaException(string message, Exception exception) : base(message, exception) { }
         public OktaException(OktaException oktaException) {

--- a/Okta.Core/Exceptions/OktaExceptionResolver.cs
+++ b/Okta.Core/Exceptions/OktaExceptionResolver.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Text;
-using Newtonsoft.Json;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+    using System.Net.Http;
+
     /// <summary>
     /// Parse an http response into an <see cref="OktaException"/>
     /// </summary>
@@ -28,14 +23,13 @@ namespace Okta.Core
                 {
                     throw new OktaRequestThrottlingException(exception);
                 }
-                else if (exception.ErrorCode == OktaErrorCodes.AuthenticationException)
+
+                if (exception.ErrorCode == OktaErrorCodes.AuthenticationException)
                 {
                     throw new OktaAuthenticationException(exception);
                 }
-                else
-                {
-                    throw exception;
-                }
+
+                throw exception;
             }
         }
     }

--- a/Okta.Core/Exceptions/OktaRequestThrottlingException.cs
+++ b/Okta.Core/Exceptions/OktaRequestThrottlingException.cs
@@ -1,19 +1,17 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An <see cref="OktaException"/> thrown for rate limiting issues
     /// </summary>
     public class OktaRequestThrottlingException : OktaException
     {
         [JsonConstructor]
-        public OktaRequestThrottlingException() : base() { }
+        public OktaRequestThrottlingException()
+        { }
         public OktaRequestThrottlingException(string message) : base(message) { }
         public OktaRequestThrottlingException(string message, Exception exception) : base(message, exception) { }
         public OktaRequestThrottlingException(OktaException oktaException) : base(oktaException) { }

--- a/Okta.Core/FilterBuilder.cs
+++ b/Okta.Core/FilterBuilder.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+    using System.Text;
+
     /// <summary>
     /// Builds a filter that follows Okta's expression language.
     /// </summary>
@@ -46,7 +43,7 @@ namespace Okta.Core
 
         public FilterBuilder Where(FilterBuilder filter)
         {
-            stringBuilder.Append("(" + filter.ToString() + ")");
+            stringBuilder.Append("(" + filter + ")");
             return this;
         }
 
@@ -96,7 +93,7 @@ namespace Okta.Core
             return EqualTo().Value(value);
         }
 
-        public FilterBuilder EqualTo(Boolean value)
+        public FilterBuilder EqualTo(bool value)
         {
             return EqualTo().Value(value);
         }

--- a/Okta.Core/Filters.cs
+++ b/Okta.Core/Filters.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
     /// <summary>
     /// Aliases for properties on each <see cref="Okta.Core.Models.OktaObject"/> type that supports filtering

--- a/Okta.Core/IOktaHttpClient.cs
+++ b/Okta.Core/IOktaHttpClient.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
     /// <summary>
     /// An abstract Okta http client
     /// </summary>
@@ -11,9 +11,9 @@ namespace Okta.Core
     {
         public enum HttpRequestType
         {
-            GET,
-            PUT,
-            POST,
+            GET, 
+            PUT, 
+            POST, 
             DELETE
         }
 
@@ -36,13 +36,14 @@ namespace Okta.Core
 
         public HttpResponseMessage Get(Uri uri)
         {
-            return Execute(HttpRequestType.GET, uri: uri);
+            return Execute(HttpRequestType.GET, uri);
         }
 
         public Task<HttpResponseMessage> GetAsync(Uri uri)
         {
-            return ExecuteAsync(HttpRequestType.GET, uri: uri);
+            return ExecuteAsync(HttpRequestType.GET, uri);
         }
+
         #endregion
 
         #region POST methods
@@ -58,13 +59,14 @@ namespace Okta.Core
 
         public HttpResponseMessage Post(Uri uri, string content)
         {
-            return Execute(HttpRequestType.POST, uri: uri, content: content);
+            return Execute(HttpRequestType.POST, uri, content: content);
         }
 
         public Task<HttpResponseMessage> PostAsync(Uri uri, string content)
         {
-            return ExecuteAsync(HttpRequestType.POST, uri: uri, content: content);
+            return ExecuteAsync(HttpRequestType.POST, uri, content: content);
         }
+
         #endregion
 
         #region PUT methods
@@ -80,13 +82,14 @@ namespace Okta.Core
 
         public HttpResponseMessage Put(Uri uri, string content = null)
         {
-            return Execute(HttpRequestType.PUT, uri: uri, content: content);
+            return Execute(HttpRequestType.PUT, uri, content: content);
         }
 
         public Task<HttpResponseMessage> PutAsync(Uri uri, string content = null)
         {
-            return ExecuteAsync(HttpRequestType.PUT, uri: uri, content: content);
+            return ExecuteAsync(HttpRequestType.PUT, uri, content: content);
         }
+
         #endregion
 
         #region DELETE methods
@@ -102,13 +105,14 @@ namespace Okta.Core
 
         public HttpResponseMessage Delete(Uri uri)
         {
-            return Execute(HttpRequestType.DELETE, uri: uri);
+            return Execute(HttpRequestType.DELETE, uri);
         }
 
         public Task<HttpResponseMessage> DeleteAsync(Uri uri)
         {
-            return ExecuteAsync(HttpRequestType.DELETE, uri: uri);
+            return ExecuteAsync(HttpRequestType.DELETE, uri);
         }
+
         #endregion
     }
 }

--- a/Okta.Core/Models/ApiObject.cs
+++ b/Okta.Core/Models/ApiObject.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json.Linq;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
     /// <summary>
     /// The foundation of all the Okta models.
     /// </summary>
@@ -14,7 +14,7 @@ namespace Okta.Core.Models
     /// This enables serialization and deserialization.
     /// </remarks>
     [JsonObject(MemberSerialization.OptIn)]
-    public partial class ApiObject
+    public class ApiObject
     {
         /// <summary>
         /// Gets or sets the changed properties.
@@ -56,10 +56,8 @@ namespace Okta.Core.Models
             {
                 return property.Value.ToString();
             }
-            else
-            {
-                throw new OktaException("Property not available: " + propertyName);
-            }
+
+            throw new OktaException("Property not available: " + propertyName);
         }
 
         /// <summary>
@@ -93,11 +91,12 @@ namespace Okta.Core.Models
             return false;
         }
         
+
         /// <summary>
         /// Get a List of all the Unmapped property names
         /// </summary>
         /// <returns></returns>
-        public List<String> GetUnmappedPropertyNames()
+        public List<string> GetUnmappedPropertyNames()
         {
             return UnmappedProperties.Keys.ToList();
         }

--- a/Okta.Core/Models/Apps/Accessibility.cs
+++ b/Okta.Core/Models/Apps/Accessibility.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Defines how an <see cref="App"/> is accessible to a <see cref="User"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/App.cs
+++ b/Okta.Core/Models/Apps/App.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An org's third party integration with Okta
     /// </summary>
@@ -30,9 +27,9 @@ namespace Okta.Core.Models
         /// <returns></returns>
         public static App BuildBookmark(string url, string label = null, bool? requestIntegration = null)
         {
-            var app = new App() {
-                Name = "bookmark",
-                Label = label,
+            var app = new App {
+                Name = "bookmark", 
+                Label = label, 
                 SignOnMode = "BOOKMARK"
             };
 
@@ -55,16 +52,14 @@ namespace Okta.Core.Models
         /// <returns></returns>
         public static App BuildBasicAuth(string url, string authUrl, string label = null)
         {
-            var app = new App()
-            {
-                Name = "template_basic_auth",
-                Label = label,
+            var app = new App {
+                Name = "template_basic_auth", 
+                Label = label, 
                 SignOnMode = "BASIC_AUTH"
             };
 
-            app.Settings.App = new AppSettings()
-            {
-                Url = url,
+            app.Settings.App = new AppSettings {
+                Url = url, 
                 AuthURL = authUrl
             };
 
@@ -83,27 +78,25 @@ namespace Okta.Core.Models
         /// <param name="extraFieldValue">The extra field value.</param>
         /// <returns></returns>
         public static App BuildSwaPlugin(
-            string url,
-            string usernameField,
-            string passwordField,
-            string buttonField,
-            string label = null,
-            string extraFieldSelector = null,
+            string url, 
+            string usernameField, 
+            string passwordField, 
+            string buttonField, 
+            string label = null, 
+            string extraFieldSelector = null, 
             string extraFieldValue = null)
         {
-            var app = new App()
-            {
-                Name = "template_swa",
-                Label = label,
+            var app = new App {
+                Name = "template_swa", 
+                Label = label, 
                 SignOnMode = "BROWSER_PLUGIN"
             };
 
-            app.Settings.App = new AppSettings()
-            {
-                UsernameField = usernameField,
-                PasswordField = passwordField,
-                ButtonField = buttonField,
-                ExtraFieldSelector = extraFieldSelector,
+            app.Settings.App = new AppSettings {
+                UsernameField = usernameField, 
+                PasswordField = passwordField, 
+                ButtonField = buttonField, 
+                ExtraFieldSelector = extraFieldSelector, 
                 ExtraFieldValue = extraFieldValue
             };
 
@@ -125,33 +118,31 @@ namespace Okta.Core.Models
         /// <param name="optionalField3Value">The optional field3 value.</param>
         /// <returns></returns>
         public static App BuildSwaNoPlugin(
-            string url,
-            string usernameField,
-            string passwordField,
-            string label = null,
-            string optionalField1 = null,
-            string optionalField1Value = null,
-            string optionalField2 = null,
-            string optionalField2Value = null,
-            string optionalField3 = null,
+            string url, 
+            string usernameField, 
+            string passwordField, 
+            string label = null, 
+            string optionalField1 = null, 
+            string optionalField1Value = null, 
+            string optionalField2 = null, 
+            string optionalField2Value = null, 
+            string optionalField3 = null, 
             string optionalField3Value = null)
         {
-            var app = new App()
-            {
-                Name = "template_sps",
-                Label = label,
+            var app = new App {
+                Name = "template_sps", 
+                Label = label, 
                 SignOnMode = "SECURE_PASSWORD_STORE"
             };
 
-            app.Settings.App = new AppSettings()
-            {
-                UsernameField = usernameField,
-                PasswordField = passwordField,
-                OptionalField1 = optionalField1,
-                OptionalField1Value = optionalField1Value,
-                OptionalField2 = optionalField2,
-                OptionalField2Value = optionalField2Value,
-                OptionalField3 = optionalField3,
+            app.Settings.App = new AppSettings {
+                UsernameField = usernameField, 
+                PasswordField = passwordField, 
+                OptionalField1 = optionalField1, 
+                OptionalField1Value = optionalField1Value, 
+                OptionalField2 = optionalField2, 
+                OptionalField2Value = optionalField2Value, 
+                OptionalField3 = optionalField3, 
                 OptionalField3Value = optionalField3Value
             };
 

--- a/Okta.Core/Models/Apps/AppCredentials.cs
+++ b/Okta.Core/Models/Apps/AppCredentials.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Description of credentials for an <see cref="App"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/AppGroup.cs
+++ b/Okta.Core/Models/Apps/AppGroup.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A group defined for an <see cref="App"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/AppLinks.cs
+++ b/Okta.Core/Models/Apps/AppLinks.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Link to an <see cref="App"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/AppSettings.cs
+++ b/Okta.Core/Models/Apps/AppSettings.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Attributes of an <see cref="App"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/AppUser.cs
+++ b/Okta.Core/Models/Apps/AppUser.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A <see cref="User"/> assigned to an <see cref="App"/>.
     /// </summary>

--- a/Okta.Core/Models/Apps/AppUserCredentials.cs
+++ b/Okta.Core/Models/Apps/AppUserCredentials.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Credentials of an <see cref="AppUser"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/Hide.cs
+++ b/Okta.Core/Models/Apps/Hide.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Where an <see cref="App"/> is visible
     /// </summary>

--- a/Okta.Core/Models/Apps/Settings.cs
+++ b/Okta.Core/Models/Apps/Settings.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Wrapper for <see cref="AppSettings"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/UserNameTemplate.cs
+++ b/Okta.Core/Models/Apps/UserNameTemplate.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Format of an <see cref="AppCredentials.UserName"/>
     /// </summary>

--- a/Okta.Core/Models/Apps/Visibility.cs
+++ b/Okta.Core/Models/Apps/Visibility.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Determines the visibility of an <see cref="App"/> to a <see cref="User"/>
     /// </summary>

--- a/Okta.Core/Models/Auth/AuthContext.cs
+++ b/Okta.Core/Models/Auth/AuthContext.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// The context of an authorization flow.
     /// </summary>

--- a/Okta.Core/Models/Auth/AuthNewPassword.cs
+++ b/Okta.Core/Models/Auth/AuthNewPassword.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An object used to reset a password during an authentication flow.
     /// </summary>

--- a/Okta.Core/Models/Auth/AuthRequest.cs
+++ b/Okta.Core/Models/Auth/AuthRequest.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A request whose goal is to obtain a session token.
     /// </summary>

--- a/Okta.Core/Models/Auth/AuthResponse.cs
+++ b/Okta.Core/Models/Auth/AuthResponse.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A response during any authentication request.
     /// </summary>

--- a/Okta.Core/Models/Auth/AuthStatus.cs
+++ b/Okta.Core/Models/Auth/AuthStatus.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
     /// <summary>
     /// The status of an authentication or recovery transaction.
@@ -16,20 +11,28 @@ namespace Okta.Core.Models
         // (Sorted according to the "Authentication Status" table in the URL above.)
         /// <summary>The user’s password was successfully validated but is expired.</summary>
         public const string PasswordExpired = "PASSWORD_EXPIRED";
+
         /// <summary>The user has requested a recovery token to reset their password or unlock their account.</summary>
         public const string Recovery = "RECOVERY";
+
         /// <summary>The user successfully answered their recovery question and must to set a new password.</summary>
         public const string PasswordReset = "PASSWORD_RESET";
+
         /// <summary>The user account is locked; self-service unlock or admin unlock is required.</summary>
         public const string LockedOut = "LOCKED_OUT";
+
         /// <summary>The user must select and enroll an available factor for additional verification.</summary>
         public const string MfaEnroll = "MFA_ENROLL";
+
         /// <summary>The user must activate the factor to complete enrollment.</summary>
         public const string MfaEnrollActivate = "MFA_ENROLL_ACTIVATE";
+
         /// <summary>The user must provide additional verification with a previously enrolled factor.</summary>
         public const string MfaRequired = "MFA_REQUIRED";
+
         /// <summary>The user must verify the factor-specific challenge.</summary>
         public const string MfaChallenge = "MFA_CHALLENGE";
+
         /// <summary>The transaction has completed successfully.</summary>
         public const string Success = "SUCCESS";
     }

--- a/Okta.Core/Models/Embedded.cs
+++ b/Okta.Core/Models/Embedded.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Read only objects that are related to another <see cref="ApiObject"/>.
     /// </summary>

--- a/Okta.Core/Models/Events/Action.cs
+++ b/Okta.Core/Models/Events/Action.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// The action performed by an <see cref="Actor"/> on a <see cref="Target"/> in an <see cref="Event"/>
     /// </summary>

--- a/Okta.Core/Models/Events/Actor.cs
+++ b/Okta.Core/Models/Events/Actor.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// The source of an <see cref="Event"/>
     /// </summary>

--- a/Okta.Core/Models/Events/Event.cs
+++ b/Okta.Core/Models/Events/Event.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A log entry for a change within an Okta org
     /// </summary>

--- a/Okta.Core/Models/Events/Target.cs
+++ b/Okta.Core/Models/Events/Target.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// The target of an <see cref="Event"/>
     /// </summary>

--- a/Okta.Core/Models/Groups/Group.cs
+++ b/Okta.Core/Models/Groups/Group.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A group of users
     /// </summary>
@@ -19,9 +14,8 @@ namespace Okta.Core.Models
 
         public Group(string name, string description)
         {
-            Profile = new GroupProfile()
-            {
-                Name = name,
+            Profile = new GroupProfile {
+                Name = name, 
                 Description = description
             };
         }

--- a/Okta.Core/Models/Groups/GroupProfile.cs
+++ b/Okta.Core/Models/Groups/GroupProfile.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A profile that describes a <see cref="Group"/>
     /// </summary>

--- a/Okta.Core/Models/Link.cs
+++ b/Okta.Core/Models/Link.cs
@@ -1,12 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A HAL link
     /// </summary>

--- a/Okta.Core/Models/LinkedObject.cs
+++ b/Okta.Core/Models/LinkedObject.cs
@@ -1,11 +1,11 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An entity that has HAL links
     /// </summary>
@@ -23,7 +23,7 @@ namespace Okta.Core.Models
         /// <value>
         /// The self URI.
         /// </value>
-        public Uri SelfUri { get { return Links.ContainsKey("self") ? ((List<Link>)Links["self"]).First().Href : null; } }
+        public Uri SelfUri { get { return Links.ContainsKey("self") ? this.Links["self"].First().Href : null; } }
 
         /// <summary>
         /// Gets or sets the HAL links of an object.

--- a/Okta.Core/Models/MFA/ChallengeResponse.cs
+++ b/Okta.Core/Models/MFA/ChallengeResponse.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A result after submitting an MFA request
     /// </summary>

--- a/Okta.Core/Models/MFA/Factor.cs
+++ b/Okta.Core/Models/MFA/Factor.cs
@@ -1,12 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An MFA factor
     /// </summary>
@@ -25,16 +23,14 @@ namespace Okta.Core.Models
         /// <returns>A question <see cref="Factor"/></returns>
         public static Factor BuildQuestion(string questionType, string answer)
         {
-            var profile = new FactorProfile()
-            {
-                QuestionType = questionType,
+            var profile = new FactorProfile {
+                QuestionType = questionType, 
                 Answer = answer
             };
 
-            return new Factor()
-            {
-                FactorType = Okta.Core.Models.FactorType.Question,
-                Provider = FactorProviderType.Okta,
+            return new Factor {
+                FactorType = Models.FactorType.Question, 
+                Provider = FactorProviderType.Okta, 
                 Profile = profile
             };
         }
@@ -47,17 +43,15 @@ namespace Okta.Core.Models
         /// <returns>An SMS <see cref="Factor"/></returns>
         public static Factor BuildSms(string phoneNumber, bool forceUpdate = false)
         {
-            var profile = new FactorProfile()
-            {
+            var profile = new FactorProfile {
                 PhoneNumber = phoneNumber
             };
 
             profile.SetProperty("updatePhone", forceUpdate);
 
-            return new Factor()
-            {
-                FactorType = Okta.Core.Models.FactorType.Sms,
-                Provider = FactorProviderType.Okta,
+            return new Factor {
+                FactorType = Models.FactorType.Sms, 
+                Provider = FactorProviderType.Okta, 
                 Profile = profile
             };
         }

--- a/Okta.Core/Models/MFA/FactorProfile.cs
+++ b/Okta.Core/Models/MFA/FactorProfile.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// MFA profile.
     /// </summary>

--- a/Okta.Core/Models/MFA/FactorProviderType.cs
+++ b/Okta.Core/Models/MFA/FactorProviderType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
     /// <summary>
     /// All supported MFA providers.

--- a/Okta.Core/Models/MFA/FactorTypes.cs
+++ b/Okta.Core/Models/MFA/FactorTypes.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
     /// <summary>
     /// All supported MFA factors

--- a/Okta.Core/Models/MFA/MfaAnswer.cs
+++ b/Okta.Core/Models/MFA/MfaAnswer.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Sent to confirm receipt of an MFA request
     /// </summary>

--- a/Okta.Core/Models/MFA/Question.cs
+++ b/Okta.Core/Models/MFA/Question.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A question used as a second factor authentication
     /// </summary>

--- a/Okta.Core/Models/OktaObject.cs
+++ b/Okta.Core/Models/OktaObject.cs
@@ -1,11 +1,10 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An entity that has an id and generally has CRUD operations available.
     /// </summary>
@@ -39,14 +38,14 @@ namespace Okta.Core.Models
         {
             if (isCreate)
             {
-                if (!String.IsNullOrEmpty(this.Id))
+                if (!string.IsNullOrEmpty(this.Id))
                 {
                     throw new OktaException("Id should be null for create.");
                 }
             }
             else
             {
-                if (String.IsNullOrEmpty(this.Id))
+                if (string.IsNullOrEmpty(this.Id))
                 {
                     throw new OktaException("Id should not be null.");
                 }

--- a/Okta.Core/Models/Schemas/Schema.cs
+++ b/Okta.Core/Models/Schemas/Schema.cs
@@ -1,11 +1,10 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models.Schemas
+﻿namespace Okta.Core.Models.Schemas
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// The Schema is defined using JSON Schema Draft 4.
     /// </summary>
@@ -15,31 +14,36 @@ namespace Okta.Core.Models.Schemas
         /// JSON Schema version identifier
         /// </summary>
         [JsonProperty("$schema")]
-        public String JsonSchemaVersion { get; private set; }
+        public string JsonSchemaVersion { get; private set; }
+
         /// <summary>
         /// The name
         /// </summary>
         [JsonProperty("name")]
-        public String Name { get; private set; }
+        public string Name { get; private set; }
+
         /// <summary>
         /// The title
         /// </summary>
         [JsonProperty("title")]
-        public String Title { get; private set; }
+        public string Title { get; private set; }
+
         /// <summary>
         /// Timestamp when schema was last updated
         /// </summary>
         [JsonProperty("lastUpdated")]
-        public String LastUpdated { get; private set; }
+        public string LastUpdated { get; private set; }
+
         /// <summary>
         /// Timestamp when schema was created
         /// </summary>
         [JsonProperty("created")]
-        public String Created { get; private set; }
+        public string Created { get; private set; }
+
         /// <summary>
         /// The Sub Schemas
         /// </summary>
         [JsonProperty("definitions")]
-        public Dictionary<String, SubSchema> SubSchemas { get; private set; }
+        public Dictionary<string, SubSchema> SubSchemas { get; private set; }
     }
 }

--- a/Okta.Core/Models/Schemas/SchemaItems.cs
+++ b/Okta.Core/Models/Schemas/SchemaItems.cs
@@ -1,0 +1,16 @@
+﻿namespace Okta.Core.Models.Schemas
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Definition of schema array items
+    /// </summary>
+    public class SchemaItems
+    {
+        /// <summary>
+        /// The type of the array items
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/Okta.Core/Models/Schemas/SchemaProperty.cs
+++ b/Okta.Core/Models/Schemas/SchemaProperty.cs
@@ -1,13 +1,9 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-
-namespace Okta.Core.Models.Schemas
+﻿namespace Okta.Core.Models.Schemas
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// The definition of a Schema property
     /// </summary>
@@ -17,36 +13,48 @@ namespace Okta.Core.Models.Schemas
         /// User-defined display name for the property
         /// </summary>
         [JsonProperty("title")]
-        public String Title { get; set; }
+        public string Title { get; set; }
+
         /// <summary>
         /// Type of property
         /// </summary>
         [JsonProperty("type")]
-        public String Type { get; set; }
+        public string Type { get; set; }
+
         /// <summary>
         /// The format
         /// </summary>
         [JsonProperty("format")]
-        public String Format { get; set; }
+        public string Format { get; set; }
+
         /// <summary>
         /// The optional maximum length for any String property
         /// </summary>
         [JsonProperty("maxLength")]
         public int? MaxLength { get; set; }
+
         /// <summary>
         /// The optional minimum length for any String property
         /// </summary>
         [JsonProperty("minLength")]
         public int? MinLength { get; set; }
+
         /// <summary>
         /// Determines whether the property is required
         /// </summary>
         [JsonProperty("required")]
         public bool Required { get; set; }
+
         /// <summary>
         /// The permissions for the property
         /// </summary>
         [JsonProperty("permissions")]
         public SchemaPropertyPermission[] Permissions { get; set; }
+        
+        /// <summary>
+        /// The type of the items.
+        /// </summary>
+        [JsonProperty("items")]
+        public SchemaItems Items { get; set; }
     }
 }

--- a/Okta.Core/Models/Schemas/SchemaPropertyPermission.cs
+++ b/Okta.Core/Models/Schemas/SchemaPropertyPermission.cs
@@ -1,22 +1,21 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models.Schemas
+﻿namespace Okta.Core.Models.Schemas
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     public class SchemaPropertyPermission
     {
         /// <summary>
         /// The security principal
         /// </summary>
         [JsonProperty("principal")]
-        public String Principal { get; set; }
+        public string Principal { get; set; }
+
         /// <summary>
         /// Determines whether the principal can view or modify the property
         /// </summary>
         [JsonProperty("action")]
-        public String Action { get; set; }
+        public string Action { get; set; }
     }
 }

--- a/Okta.Core/Models/Schemas/SubSchema.cs
+++ b/Okta.Core/Models/Schemas/SubSchema.cs
@@ -1,32 +1,34 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models.Schemas
+﻿namespace Okta.Core.Models.Schemas
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
     public class SubSchema
     {
         /// <summary>
         /// Sub Schema Id
         /// </summary>
         [JsonProperty("id")]
-        public String Id { get; private set; }
+        public string Id { get; private set; }
+
         /// <summary>
         /// Sub Schema type
         /// </summary>
         [JsonProperty("type")]
-        public String Type { get; private set; }
+        public string Type { get; private set; }
+
         /// <summary>
         /// The properties of the Sub Schema
         /// </summary>
         [JsonProperty("properties")]
-        public Dictionary<String, SchemaProperty> Properties { get; private set; }
+        public Dictionary<string, SchemaProperty> Properties { get; private set; }
+
         /// <summary>
         /// List of required property names
         /// </summary>
         [JsonProperty("required")]
-        public List<String> RequiredProperties { get; private set; }
+        public List<string> RequiredProperties { get; private set; }
     }
 }

--- a/Okta.Core/Models/Sessions/Session.cs
+++ b/Okta.Core/Models/Sessions/Session.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An Okta user session
     /// </summary>

--- a/Okta.Core/Models/Sessions/TokenAttributes.cs
+++ b/Okta.Core/Models/Sessions/TokenAttributes.cs
@@ -1,14 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using System.Runtime.Serialization;
-using Newtonsoft.Json.Converters;
-
 namespace Okta.Core.Models
 {
+    using System.Runtime.Serialization;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
     /// <summary>
     /// The types of tokens available when requesting a <see cref="Session"/>
     /// </summary>
@@ -19,7 +15,7 @@ namespace Okta.Core.Models
         /// Manually set a cookie
         /// </summary>
         [EnumMember(Value = "cookieToken")]
-        CookieToken,
+        CookieToken, 
 
         /// <summary>
         /// Set a cookie when the user clicks a URL

--- a/Okta.Core/Models/Users/ActivationResponse.cs
+++ b/Okta.Core/Models/Users/ActivationResponse.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A response received after attempting to activate a <see cref="User"/>
     /// </summary>

--- a/Okta.Core/Models/Users/AppLink.cs
+++ b/Okta.Core/Models/Users/AppLink.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A link between a <see cref="User"/> and an <see cref="App"/>
     /// </summary>

--- a/Okta.Core/Models/Users/ExpirePasswordResponse.cs
+++ b/Okta.Core/Models/Users/ExpirePasswordResponse.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A response received after making an expire password request if an email wasn't sent instead.
     /// </summary>

--- a/Okta.Core/Models/Users/ForgotPasswordResponse.cs
+++ b/Okta.Core/Models/Users/ForgotPasswordResponse.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A response received after making a forgot password request.
     /// </summary>

--- a/Okta.Core/Models/Users/LoginCredentials.cs
+++ b/Okta.Core/Models/Users/LoginCredentials.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A user's login credentials.
     /// </summary>

--- a/Okta.Core/Models/Users/Password.cs
+++ b/Okta.Core/Models/Users/Password.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A user's password
     /// </summary>

--- a/Okta.Core/Models/Users/Provider.cs
+++ b/Okta.Core/Models/Users/Provider.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// The master of a user's profile
     /// </summary>

--- a/Okta.Core/Models/Users/RecoveryQuestion.cs
+++ b/Okta.Core/Models/Users/RecoveryQuestion.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A question and answer that allow a user to make changes to their account.
     /// </summary>

--- a/Okta.Core/Models/Users/User.cs
+++ b/Okta.Core/Models/Users/User.cs
@@ -1,11 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
+    using System;
+
+    using Newtonsoft.Json;
+
     /// <summary>
     /// An Okta user.
     /// </summary>
@@ -29,12 +27,12 @@ namespace Okta.Core.Models
         /// <param name="SecondaryEmail">User's secondary email</param>
         public User(string Login, string Email, string FirstName, string LastName, string MobilePhone = null, string SecondaryEmail = null)
         {
-            Profile = new UserProfile(){
-                Login = Login,
-                Email = Email,
-                FirstName = FirstName,
-                LastName = LastName,
-                MobilePhone = MobilePhone,
+            Profile = new UserProfile {
+                Login = Login, 
+                Email = Email, 
+                FirstName = FirstName, 
+                LastName = LastName, 
+                MobilePhone = MobilePhone, 
                 SecondaryEmail = SecondaryEmail
             };
         }

--- a/Okta.Core/Models/Users/UserProfile.cs
+++ b/Okta.Core/Models/Users/UserProfile.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Okta.Core.Models
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A user's profile.
     /// </summary>

--- a/Okta.Core/Models/Users/UserStatus.cs
+++ b/Okta.Core/Models/Users/UserStatus.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Okta.Core.Models
+﻿namespace Okta.Core.Models
 {
     /// <summary>
     /// The possible statuses of a user.

--- a/Okta.Core/Okta.Core.csproj
+++ b/Okta.Core/Okta.Core.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Models\Mfa\FactorProviderType.cs" />
     <Compile Include="Models\Mfa\FactorTypes.cs" />
     <Compile Include="Models\Schemas\Schema.cs" />
+    <Compile Include="Models\Schemas\SchemaItems.cs" />
     <Compile Include="Models\Schemas\SchemaProperty.cs" />
     <Compile Include="Models\Schemas\SchemaPropertyPermission.cs" />
     <Compile Include="Models\Schemas\SubSchema.cs" />

--- a/Okta.Core/OktaSettings.cs
+++ b/Okta.Core/OktaSettings.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Net.Http;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+    using System.Net.Http;
+
     /// <summary>
     /// Custom settings for creating an Okta client
     /// </summary>
@@ -53,9 +50,9 @@ namespace Okta.Core
         {
             set
             {
-                if (!String.IsNullOrEmpty(value))
+                if (!string.IsNullOrEmpty(value))
                 {
-                    BaseUri = new Uri(String.Format(Constants.BaseUriFormat, value));
+                    BaseUri = new Uri(string.Format(Constants.BaseUriFormat, value));
                 }
             }
         }
@@ -80,12 +77,34 @@ namespace Okta.Core
             {
                 if (value > Constants.MaxPageSize)
                 {
-                    throw new OktaException("The SDK doesn't allow page sizes greater than " + Constants.MaxPageSize.ToString());
+                    throw new OktaException("The SDK doesn't allow page sizes greater than " + Constants.MaxPageSize);
                 }
-                else
-                {
-                    _pageSize = value;
-                }
+
+                this._pageSize = value;
+            }
+        }
+
+        private string _userAgent = Constants.UserAgent;
+
+
+        /// <summary>
+        /// Gets or sets the user agent.
+        /// </summary>
+        /// <value>
+        /// The user agent.
+        /// </value>
+        public string UserAgent
+        {
+            get
+            {
+                return this._userAgent;
+            }
+
+            set
+            {
+                this._userAgent = string.IsNullOrWhiteSpace(value) 
+                    ? Constants.UserAgent 
+                    : string.Format("{0} ({1})", value, Constants.UserAgent);
             }
         }
     }

--- a/Okta.Core/PagedResults.cs
+++ b/Okta.Core/PagedResults.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Okta.Core.Models;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Okta.Core.Models;
+
     /// <summary>
     /// A single page of <see cref="Okta.Core.Models.OktaObject"/>s
     /// </summary>
@@ -25,6 +25,7 @@ namespace Okta.Core
                 Read = true;
                 return _results;
             }
+
             private set
             {
                 _results = value;

--- a/Okta.Core/Properties/AssemblyInfo.cs
+++ b/Okta.Core/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
-﻿using System.Resources;
-using System.Reflection;
+﻿using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -17,12 +16,10 @@ using System.Runtime.InteropServices;
 [assembly: NeutralResourcesLanguage("en")]
 
 // Version information for an assembly consists of the following four values:
-//
 //      Major Version
 //      Minor Version 
 //      Build Number
 //      Revision
-//
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]

--- a/Okta.Core/Utils.cs
+++ b/Okta.Core/Utils.cs
@@ -1,15 +1,15 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using Newtonsoft.Json.Linq;
-using System.Net.Http;
-using System.Text.RegularExpressions;
-
-namespace Okta.Core
+﻿namespace Okta.Core
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Reflection;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+
+    using Newtonsoft.Json;
+
     internal class Utils
     {
         public static Tuple<string, Uri> ParseLinkHeader(string header)
@@ -85,7 +85,7 @@ namespace Okta.Core
         {
             try
             {
-                return JsonConvert.DeserializeObject(value.ToString(), type, oktaJsonConverter);
+                return JsonConvert.DeserializeObject(value, type, oktaJsonConverter);
             }
             catch (Exception e)
             {
@@ -125,14 +125,15 @@ namespace Okta.Core
         {
             if (urlParams == null || urlParams.Count < 1)
             {
-                return "";
+                return string.Empty;
             }
 
             var paramList = new List<string>();
             foreach (var kvp in urlParams)
             {
-                paramList.Add(kvp.Key + "=" + kvp.Value.ToString());
+                paramList.Add(kvp.Key + "=" + kvp.Value);
             }
+
             return "?" + string.Join("&", paramList);
         }
 
@@ -150,17 +151,7 @@ namespace Okta.Core
 
         public static string GetAssemblyVersion()
         {
-            var regex = new Regex(@"Version=[\d\.]*");
-            var fullAssemblyName = typeof(Utils).Assembly.FullName;
-            var match = regex.Match(fullAssemblyName);
-            if (match.Success)
-            {
-                return match.Value.Split('=')[1];
-            }
-            else
-            {
-                return String.Empty;
-            }
+            return new AssemblyName(typeof(Utils).Assembly.FullName).Version.ToString();
         }
     }
 }


### PR DESCRIPTION
- Expose the item type of an array in the schema models
- Make all the public methods in the clients virtual to allow consumers to easily mock the methods for improved testability
- Fix exception rethrows so that they preserve the original stack trace
- Ran Resharper to perform some code cleanup and remove redundant code

Relates to: OKTA-77612