### PR TITLE
:seedling: Add TryGetProperty method

### DIFF
--- a/Okta.Core/Models/ApiObject.cs
+++ b/Okta.Core/Models/ApiObject.cs
@@ -78,6 +78,19 @@
         }
 
         /// <summary>
+        /// Tries to get a property.
+        /// </summary>
+        /// <param name="propertyName">Name of the property</param>
+        /// <param name="value">The returned value.</param>
+        /// <returns><c>true</c> if <c>propertyName</c> exists.</returns>
+        public bool TryGetProperty(string propertyName, out string value)
+        {
+            bool found = UnmappedProperties.TryGetValue(propertyName, out var property);
+            value = property?.Value?.ToString();
+            return found;
+        }
+
+        /// <summary>
         /// Checks for the availability of an unmapped property.
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>


### PR DESCRIPTION
Adds a `TryGetProperty` method to the base class to complement `GetProperty` and `ContainsProperty`. Delegates to the TryGet implementation in the dictionary.